### PR TITLE
Bump library version

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TelnetSpy
-version=1.1
+version=1.2
 author=Wolfgang Mattis (Y)
 maintainer=Wolfgang Mattis (Y)
 sentence=Cloning the serial port via Telnet / Debugging "over the air" (for ESP8266/ESP32)


### PR DESCRIPTION
Please merge #16 first and then this, then it becomes a compilable library again.

We have users at https://community.platformio.org/t/getting-an-error-that-a-class-has-no-member-named/20473 that wonder why the `setCallbackOnConnect()` e.g. that is in the header file at this repo is not available when downloading the library via the library manager -- this is because no new version of the library has been released since where this function is included.

Only the bugfix in #16 makes it compile though. The version update will then trigger an update in all the library maanger sites.